### PR TITLE
Fix: Correct loop unrolling label logic and add ASM test formatter

### DIFF
--- a/assembler/utils_print.go
+++ b/assembler/utils_print.go
@@ -44,6 +44,88 @@ func DumpBasicString(asm *Assembler) string {
 	return sb.String()
 }
 
+// FormatAsm はAssembler構造体からアセンブリファイルのテキスト表現を生成します。
+// GenerateAsmと似ていますが、テストの比較表示に適した形式で出力します。
+func FormatAsm(asm *Assembler) string {
+	if asm == nil {
+		return "Assembler is nil\n"
+	}
+
+	var sb strings.Builder
+
+	// アドレスからラベル名への逆引きマップを作成 (同じアドレスに複数のラベルを格納できるようにする)
+	labelsByAddr := make(map[int][]string)
+	for name, addr := range asm.Labels {
+		labelsByAddr[addr] = append(labelsByAddr[addr], name)
+	}
+
+	// 出力済みのラベルを記録するセット
+	emittedLabels := make(map[string]bool)
+
+	// プログラム内の命令とラベルを出力
+	for _, instruction := range asm.Program {
+		// アドレスに対応するラベルがあればすべて出力
+		if labelNames, ok := labelsByAddr[instruction.Addr]; ok {
+			for _, labelName := range labelNames {
+				if !emittedLabels[labelName] {
+					sb.WriteString(labelName)
+					sb.WriteString(":\n")
+					emittedLabels[labelName] = true
+				}
+			}
+		}
+
+		// 命令の出力 (インデント付き)
+		sb.WriteString("\t")
+		if instruction.OpCode.Mnemonic == "<-" && len(instruction.OpCode.Operands) == 2 {
+			sb.WriteString(instruction.OpCode.Operands[0])
+			sb.WriteString(" <- ")
+			sb.WriteString(instruction.OpCode.Operands[1])
+		} else {
+			sb.WriteString(instruction.OpCode.Mnemonic)
+			if len(instruction.OpCode.Operands) > 0 {
+				operands := strings.Join(instruction.OpCode.Operands, ", ")
+				if operands != "" { // spbarrのようなオペランドが空文字列の場合に対応
+					sb.WriteString(" ")
+					sb.WriteString(operands)
+				}
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// プログラム末尾のラベルを出力 (命令に関連付けられていないラベル)
+	// プログラムが空の場合や、最後の命令の後にラベルがある場合に対応
+	maxAddr := -1
+	if len(asm.Program) > 0 {
+		maxAddr = asm.Program[len(asm.Program)-1].Addr
+	}
+
+	// プログラムの最大アドレスよりも大きいアドレスを持つラベルを出力
+	// （ソートはしないので、ラベルの順序は保証されないが、テスト目的では十分）
+	for addr, labelNames := range labelsByAddr {
+		if addr > maxAddr { // 最後の命令のアドレスより大きい、またはプログラムが空(-1)の場合
+			// プログラムが空でラベルのみ存在する場合も考慮
+			isInstructionAtAddr := false
+			for _, instr := range asm.Program {
+				if instr.Addr == addr {
+					isInstructionAtAddr = true
+					break
+				}
+			}
+			if !isInstructionAtAddr { // このアドレスに命令がなければラベルを出力
+				for _, labelName := range labelNames {
+					if !emittedLabels[labelName] {
+						sb.WriteString(labelName)
+						sb.WriteString(":\n")
+						emittedLabels[labelName] = true
+					}
+				}
+			}
+		}
+	}
+	return sb.String()
+}
 
 func DumpFormatted(asm *Assembler) {
     if asm == nil {


### PR DESCRIPTION
This commit corrects the label renaming mechanism within the loop expander for more robust unrolling and introduces a new assembly formatting utility to aid in testing.

Key changes:

assembler/utils_print.go:
- Add `FormatAsm` function: Generates a canonical string representation of assembly code, specifically designed for easier comparison and verification in tests. It correctly handles multiple labels per address, labels at the program end, and formats instructions consistently, including special mnemonics like "<-".

loop_expander/loop_expander.go:
- Correct label renaming logic during loop unrolling:
  - Ensure labels are accurately suffixed based on their original definition relative to the current instruction and unrolling iteration. This resolves issues with forward/backward jumps to labels within the loop body and jumps to labels defined outside the loop.
  - Implement special handling for the "programEnd" label to prevent it from being incorrectly versioned during unrolling.

loop_expander/loop_expander_test.go:
- Add "Complex Loop with Multiple Internal Labels" test case to validate the corrected label handling in the loop expander.